### PR TITLE
No duplicates

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,8 +71,10 @@ export default class ReactTagInput extends React.Component<ReactTagInputProps, S
 
   addTag = (value: string) => {
     const tags = [ ...this.props.tags ];
-    tags.push(value);
-    this.props.onChange(tags);
+    if (!tags.includes(value)) {
+      tags.push(value);
+      this.props.onChange(tags);
+    }
     this.setState({ input: "" });
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,12 @@ export default class ReactTagInput extends React.Component<ReactTagInputProps, S
 
   updateTag = (i: number, value: string) => {
     const tags = [...this.props.tags];
-    tags[i] = value;
+    const numOccurencesOfValue = tags.reduce((prev, currentValue, index) => prev + (currentValue === value && index !== i ? 1 : 0) , 0);
+    if (numOccurencesOfValue > 0) {
+      tags.splice(i, 1);
+    } else {
+      tags[i] = value;
+    }
     this.props.onChange(tags);
   }
 


### PR DESCRIPTION
This PR makes sure that one cannot enter a tag twice.

It does this:

1. Upon add: if the entered value already appears in the tags array it won't be added.
2. Upon edit: if the new value is a duplicate one, then the (duplicate) entry gets removed.

Do note that the check is case-sensitive, so one will be able to enter both `foo` and `Foo`.