### PR TITLE
Added support for user-defined keycodes

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -14,6 +14,7 @@ const initialSettings: ReactTagInputProps = {
   readOnly: false,
   removeOnBackspace: true,
   validator: undefined,
+  additionalKeycodes: [9, 32, 188]
 };
 
 function Example() {

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -8,13 +8,13 @@ const root = document.getElementById("root");
 const initialSettings: ReactTagInputProps = {
   tags: [],
   onChange: (tags) => {},
-  placeholder: "Types and press enter",
+  placeholder: "Type and press enter, tab, space or comma",
   maxTags: 10,
   editable: true,
   readOnly: false,
   removeOnBackspace: true,
   validator: undefined,
-  additionalKeycodes: [9, 32, 188]
+  additionalKeycodes: [9, 32, 188] // tab, space, comma
 };
 
 function Example() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import {Tag} from "./components/Tag";
 import {classSelectors} from "./utils/selectors";
 
 type Tags = string[];
+type Keycodes = number[];
 
 export interface ReactTagInputProps {
   tags: Tags;
@@ -13,6 +14,7 @@ export interface ReactTagInputProps {
   editable?: boolean;
   readOnly?: boolean;
   removeOnBackspace?: boolean;
+  additionalKeycodes?: Keycodes;
 }
 
 interface State {
@@ -35,8 +37,8 @@ export default class ReactTagInput extends React.Component<ReactTagInputProps, S
     const { input } = this.state;
     const { validator, removeOnBackspace } = this.props;
 
-    // On enter
-    if (e.keyCode === 13) {
+    // On enter, or one of the additional keycodes from props
+    if (e.keyCode === 13 || this.props?.additionalKeycodes?.includes(e.keyCode)) {
 
       // Prevent form submission if tag input is nested in <form>
       e.preventDefault();


### PR DESCRIPTION
Hi,

Here's a PR for your consideration, which allows users to specify additional keycodes which trigger adding a tag based on the current input value. Currently, this only happens with the user presses `Enter` (13), but this change allows users to specify an optional array of `additionalKeycodes` which can result in a tag being added e.g. `comma, space, tab` etc.

I have updated `example/index.tsx` accordingly to illustrate how this would work. The new property is optional and so has no impact on the current functionality if it is not provided.

```
const initialSettings: ReactTagInputProps = {
  tags: [],
  onChange: (tags) => {},
  placeholder: "Type and press enter, tab, space or comma",
  maxTags: 10,
  editable: true,
  readOnly: false,
  removeOnBackspace: true,
  validator: undefined,
  additionalKeycodes: [9, 32, 188]  // tab, space, comma
};
```

Thanks,

J

