### PR TITLE
Converted project to functional. Allowed forwarding refs + classNames

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 120,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -964,9 +964,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
       "dev": true
     },
     "@types/q": {
@@ -976,23 +976,30 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.15.tgz",
-      "integrity": "sha512-WsmM1b6xQn1tG3X2Hx4F3bZwc2E82pJXt5OPs2YJgg71IzvUoKOSSSYOvLXYCg1ttipM+UuA4Lj3sfvqjVxyZw==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "@types/react-dom": {
-      "version": "16.9.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.4.tgz",
-      "integrity": "sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dev": true,
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "abab": {
       "version": "2.0.3",
@@ -2319,9 +2326,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
       "dev": true
     },
     "dashdash": {
@@ -5751,17 +5758,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "psl": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
@@ -5880,33 +5876,25 @@
       "dev": true
     },
     "react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-dom": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.18.0"
+        "scheduler": "^0.20.2"
       }
-    },
-    "react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-      "dev": true
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -6240,9 +6228,9 @@
       }
     },
     "scheduler": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -7052,9 +7040,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -31,16 +31,16 @@
   "author": "pathof.dev",
   "license": "MIT",
   "devDependencies": {
-    "@types/react": "^16.8.25",
-    "@types/react-dom": "^16.8.5",
+    "@types/react": "^17.0.39",
+    "@types/react-dom": "^17.0.11",
     "parcel": "^1.12.3",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "rollup": "^1.19.4",
     "sass": "^1.2.3",
     "tslint": "^5.18.0",
     "tslint-language-service": "^0.9.9",
-    "typescript": "^3.5.3",
+    "typescript": "^4.5.5",
     "uglify-js": "^3.6.0"
   }
 }

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,51 +1,42 @@
 import React from "react";
-import {classSelectors} from "../utils/selectors";
-import {ContentEditable} from "./ContentEditable";
+import { classSelectors } from "../utils/selectors";
+import ContentEditable from "./ContentEditable";
 
 interface Props {
   value: string;
   index: number;
   editable: boolean;
   readOnly: boolean;
-  inputRef: React.RefObject<HTMLInputElement>;
   update: (i: number, value: string) => void;
   remove: (i: number) => void;
   validator?: (val: string) => boolean;
   removeOnBackspace?: boolean;
 }
 
-export class Tag extends React.Component<Props> {
+const Tag = React.forwardRef<HTMLInputElement, Props>(({ value, index, editable, readOnly, update, remove, validator, removeOnBackspace }, ref) => {
 
-  innerEditableRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const removeTag = () => remove(index);
 
-  remove = () => this.props.remove(this.props.index);
+  const tagRemoveClass = !readOnly ?
+    classSelectors.tagRemove : `${classSelectors.tagRemove} ${classSelectors.tagRemoveReadOnly}`;
 
-  render() {
+  return (
+    <div className={classSelectors.tag}>
+      {!editable && <div className={classSelectors.tagContent}>{value}</div>}
+      {editable && (
+        <ContentEditable
+          value={value}
+          ref={ref}
+          className={classSelectors.tagContent}
+          change={(newValue) => update(index, newValue)}
+          remove={removeTag}
+          validator={validator}
+          removeOnBackspace={removeOnBackspace}
+        />
+      )}
+      <div className={tagRemoveClass} onClick={removeTag} ></div>
+    </div>
+  );
+});
 
-    const { value, index, editable, inputRef, validator, update, readOnly, removeOnBackspace } = this.props;
-
-    const tagRemoveClass = !readOnly ?
-      classSelectors.tagRemove : `${classSelectors.tagRemove} ${classSelectors.tagRemoveReadOnly}`;
-
-    return (
-      <div className={classSelectors.tag}>
-        {!editable && <div className={classSelectors.tagContent}>{value}</div>}
-        {editable && (
-          <ContentEditable
-            value={value}
-            inputRef={inputRef}
-            innerEditableRef={this.innerEditableRef}
-            className={classSelectors.tagContent}
-            change={(newValue) => update(index, newValue)}
-            remove={this.remove}
-            validator={validator}
-            removeOnBackspace={removeOnBackspace}
-          />
-        )}
-        <div className={tagRemoveClass} onClick={this.remove}/>
-      </div>
-    );
-
-  }
-
-}
+export default Tag;

--- a/src/utils/functions.tsx
+++ b/src/utils/functions.tsx
@@ -15,7 +15,7 @@ const htmlEntityMap = {
   "=": "&#x3D;",
 };
 export function escapeHtml(value: string) {
-  return String(value).replace(/[&<>"'`=\/]/g, (s) => {
+  return String(value).replace(/[&<>"'`=/]/g, (s) => {
     // @ts-ignore
     return htmlEntityMap[s];
   });


### PR DESCRIPTION
Converted the project to functional components and hooks. Upgraded react packages and typescript. Allowed forwarding refs from the parent for uses with libraries like React Hook Form. Added props for `wrapperClass` and `inputClass`. Added prettier config (although this is a preference and can be removed if required).